### PR TITLE
Enable drag_and_drop for windows os

### DIFF
--- a/crates/bevy_winit/src/winit_windows.rs
+++ b/crates/bevy_winit/src/winit_windows.rs
@@ -20,7 +20,7 @@ impl WinitWindows {
         #[cfg(target_os = "windows")]
         let mut winit_window_builder = {
             use winit::platform::windows::WindowBuilderExtWindows;
-            winit::window::WindowBuilder::new().with_drag_and_drop(false)
+            winit::window::WindowBuilder::new().with_drag_and_drop(true)
         };
 
         #[cfg(not(target_os = "windows"))]

--- a/examples/app/drag_and_drop.rs
+++ b/examples/app/drag_and_drop.rs
@@ -2,7 +2,9 @@ use bevy::prelude::*;
 
 fn main() {
     App::build()
-        .add_plugins(DefaultPlugins)
+        .add_plugins_with(DefaultPlugins, |group| {
+            group.disable::<bevy::audio::AudioPlugin>()
+        })
         .add_system(file_drag_and_drop_system.system())
         .run();
 }


### PR DESCRIPTION
Windows's realization WinitWindow use Builder with drag_and_drop flag off, because AudioPlugin(for windows) use multithreaded COM library (rodio->cpal)

We can enable the drag_and_drop flag, but now AudioPlugin had crush our application on Windows